### PR TITLE
Add kwarg `show_colorbar` to funtions called by `gridplot`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoVista"
 uuid = "646e1f28-b900-46d7-9d87-d554eb38a413"
-authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>"]
-version = "1.0.2"
+authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
+version = "1.1.0"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/src/plutovistaplot.jl
+++ b/src/plutovistaplot.jl
@@ -241,6 +241,7 @@ Keyword arguments:
 - `edges`: `2 x n_edges` optional  array of point indices describing edges
 - `edgemarkers=nothing`: optional `n_edges` vector of integer edge markers
 - `edgecolormap=nothing`: optional colormap for edge markers
+- `show_colorbar=true`: optional show the colorbar next to the plot
 
 """
 trimesh(pts,tris; kwargs...)=trimesh!(PlutoVistaPlot(;kwargs...),pts,tris; kwargs...)
@@ -348,6 +349,7 @@ Keyword arguments:
 - `yplanes`: array of y coordinate values for cut-off in y-direction
 - `zplanes`: array of z coordinate values for cut-off in z-direction
 - `outlinealpha=0.1`: alpha value for outline. Outliene is for value 0.0
+- `show_colorbar=true`: optional show the colorbar next to the plot
 """
 tetmesh(pts,tets; kwargs...)=tetmesh!(PlutoVistaPlot(;kwargs...),pts,tets; kwargs...)
 

--- a/src/plutovtkplot.jl
+++ b/src/plutovtkplot.jl
@@ -409,7 +409,9 @@ function trimesh!(p::PlutoVTKPlot, pts, tris; kwargs...)
                     edges = nothing,
                     gridscale = 1.0,
                     edgemarkers = nothing,
-                    edgecolormap = nothing)
+                    edgecolormap = nothing,
+                    show_colorbar = true
+                   )
 
     args = merge(p.args, default_args)
     args = merge(args, kwargs)
@@ -446,14 +448,16 @@ function trimesh!(p::PlutoVTKPlot, pts, tris; kwargs...)
         rgb = reinterpret(Float64, get(cmap, markers, (1, size(cmap))))
         parameter!(p, "colors", UInt8.(floor.(rgb * 255)))
 
-        bar_stops = collect(1:size(cmap))
-        bar_rgb = reinterpret(Float64, get(cmap, bar_stops, (1, size(cmap))))
-        bar_rgb = UInt8.(floor.(bar_rgb * 255))
-        p.jsdict["cbar"] = 2
-        p.jsdict["cbar_stops"] = bar_stops
-        p.jsdict["cbar_colors"] = bar_rgb
-        p.jsdict["cbar_levels"] = collect(1:size(cmap))
-        p.jsdict["cbar_fontsize"] = args[:legendfontsize]
+        if args[:show_colorbar]
+            bar_stops = collect(1:size(cmap))
+            bar_rgb = reinterpret(Float64, get(cmap, bar_stops, (1, size(cmap))))
+            bar_rgb = UInt8.(floor.(bar_rgb * 255))
+            p.jsdict["cbar"] = 2
+            p.jsdict["cbar_stops"] = bar_stops
+            p.jsdict["cbar_colors"] = bar_rgb
+            p.jsdict["cbar_levels"] = collect(1:size(cmap))
+            p.jsdict["cbar_fontsize"] = args[:legendfontsize]
+        end
 
     else
         parameter!(p, "colors", "none")
@@ -516,6 +520,7 @@ function tetmesh!(p::PlutoVTKPlot, pts, tets; kwargs...)
                     facemarkers = nothing,
                     gridscale = 1.0,
                     facecolormap = nothing,
+                    show_colorbar = true,
                     xplanes = [prevfloat(Inf)],
                     yplanes = [prevfloat(Inf)],
                     zplanes = [prevfloat(Inf)],
@@ -587,14 +592,16 @@ function tetmesh!(p::PlutoVTKPlot, pts, tets; kwargs...)
     rgb = reinterpret(Float64, get(cmap, regmarkers, (1, size(cmap))))
     nfaces = length(rgb) ÷ 3
 
-    bar_stops = collect(1:size(cmap))
-    bar_rgb = reinterpret(Float64, get(cmap, bar_stops, (1, size(cmap))))
-    bar_rgb = UInt8.(floor.(bar_rgb * 255))
-    p.jsdict["cbar"] = 2
-    p.jsdict["cbar_stops"] = bar_stops
-    p.jsdict["cbar_colors"] = bar_rgb
-    p.jsdict["cbar_levels"] = collect(1:size(cmap))
-    p.jsdict["cbar_fontsize"] = args[:legendfontsize]
+    if args[:show_colorbar]
+        bar_stops = collect(1:size(cmap))
+        bar_rgb = reinterpret(Float64, get(cmap, bar_stops, (1, size(cmap))))
+        bar_rgb = UInt8.(floor.(bar_rgb * 255))
+        p.jsdict["cbar"] = 2
+        p.jsdict["cbar_stops"] = bar_stops
+        p.jsdict["cbar_colors"] = bar_rgb
+        p.jsdict["cbar_levels"] = collect(1:size(cmap))
+        p.jsdict["cbar_fontsize"] = args[:legendfontsize]
+    end
 
     if faces != nothing
         bregpoints0, bregfacets0 = extract_visible_bfaces3D(pts, faces, facemarkers, nbregions,


### PR DESCRIPTION
This adds a kwarg `show_colorbar` to the 2d/3d grid plots with PlutoVista.

`gridplot(grid, Plotter=PlutoVista, show_colorbar=false)`
![image](https://github.com/user-attachments/assets/bb272738-aa6c-4ba3-97e1-5087406ca73c)

`gridplot(grid, Plotter=PlutoVista, show_colorbar=true)`  (`true` is default!)
![image](https://github.com/user-attachments/assets/dcf7e15e-f9e7-4503-ad84-ff1af57feeb6)

See also https://github.com/WIAS-PDELib/GridVisualize.jl/pull/42